### PR TITLE
Rename image_test to prevent unit test issues

### DIFF
--- a/test/TestReadme.md
+++ b/test/TestReadme.md
@@ -6,7 +6,7 @@ is a good thing to do.  However, it is complicated.  Additionally the existing
 tests are complicated too where they use PHPUnit.  I understand the principle
 being close to JUnit but is a learning curve.  Therefore at the current moment
 in time I'm going to concentrate on manual test plans and small semi-automated
-bespoke unit tests as already started with 'image_test.php'.
+bespoke unit tests as already started with 'test_image.php'.
 
 This file contains a series of 'test plans' that are performed manually to
 prove that the functionality operates correctly.  They are by no means complete.
@@ -41,7 +41,7 @@ then goes on to confirm that the image is converted for use and the displayed
 version is created.
 
 1. Whilst logged in, open a new tab / window and type:
-   your moodle installation/course/format/grid/test/image_test.php?=courseid=X
+   your moodle installation/course/format/grid/test/test_image.php?=courseid=X
 
    Where 'your moodle installation' is the start of the Moodle installation URL
    and 'X' is the course id from 'Test preparation'.

--- a/test/test_image.php
+++ b/test/test_image.php
@@ -25,10 +25,10 @@
  */
 // Instructions.
 // 1.  Ensure this file and the image '515-797no09sa.jpg' are in the Moodle installation folder '/course/format/grid/test'.
-// 2.  Ensure the value of courseid is for a valid course in the URL i.e. image_test.php?courseid=2.
+// 2.  Ensure the value of courseid is for a valid course in the URL i.e. test_image.php?courseid=2.
 // 3.1 In a browser, log into Moodle so that you have a valid MoodleSession cookie.
-// 3.2 In another tab of the same browser navigate to 'your moodle installation'/course/format/grid/test/image_test.php.
-//     E.g. http://localhost/moodlegjb/course/format/grid/test/image_test.php.
+// 3.2 In another tab of the same browser navigate to 'your moodle installation'/course/format/grid/test/test_image.php.
+//     E.g. http://localhost/moodlegjb/course/format/grid/test/test_image.php.
 // Success: Image shows.
 // Failure: Image does not show.
 


### PR DESCRIPTION
If you run moodle's course/ unit tests they fail with a fatal error on image_test.php as
it is a *_test.php file and php unit treats it as a php unit test file.

Hi Gareth,

Steps to replicate:
php admin/tool/phpunit/cli/init.php
php admin/tool/phpunit/cli/util.php --buildcomponentconfigs
vendor/bin/phpunit -c course/