### PR TITLE
updated php4 constructor

### DIFF
--- a/js/gf_colourpopup.php
+++ b/js/gf_colourpopup.php
@@ -41,9 +41,16 @@ class MoodleQuickForm_gfcolourpopup extends HTML_QuickForm_text {
     public $_helpbutton = '';
     public $_hiddenLabel = false;
 
+    public function __construct($elementName = null, $elementLabel = null, $attributes = null, $options = null) {
+        parent::__construct($elementName, $elementLabel, $attributes);
+        $this->setType('colourtext');
+    }
+
+    /*
+     * PHP4 constructor method, kept for compatibility
+     */
     public function MoodleQuickForm_gfcolourpopup($elementName = null, $elementLabel = null, $attributes = null, $options = null) {
-        parent::HTML_QuickForm_text($elementName, $elementLabel, $attributes);
-        $this->_type = 'colourtext';
+        self::__construct($elementName, $elementLabel, $attributes, $options);
     }
 
     public function setHiddenLabel($hiddenLabel) {


### PR DESCRIPTION
PHP7 falls over if a method name the same as the class name isn't used without a __construct method. This fixes that.