### PR TITLE
Replaced pix_url() calls with image_url()

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -297,7 +297,7 @@ class format_grid_renderer extends format_section_renderer_base {
 
         if ($editing) {
             $streditsummary = get_string('editsummary');
-            $urlpicedit = $this->output->pix_url('t/edit');
+            $urlpicedit = $this->output->image_url('t/edit');
         } else {
             $urlpicedit = false;
             $streditsummary = '';
@@ -361,7 +361,7 @@ class format_grid_renderer extends format_section_renderer_base {
             }
             echo html_writer::tag('img', '', array('id' => 'gridshadebox_close', 'style' => 'display: none;',
                 'class' => $deviceextra,
-                'src' => $this->output->pix_url('close', 'format_grid'),
+                'src' => $this->output->image_url('close', 'format_grid'),
                 'role' => 'link',
                 'aria-label' => get_string('closeshadebox', 'format_grid')));
 
@@ -382,7 +382,7 @@ class format_grid_renderer extends format_section_renderer_base {
                     'role' => 'link',
                     'aria-label' => get_string('previoussection', 'format_grid')));
                 $prev .= html_writer::tag('img', '', array('class' => 'gridshadebox_arrow gridshadebox_previous'.$deviceextra,
-                    'src' => $this->output->pix_url('fa-arrow-circle-'.$previcon.'-w', 'format_grid')));
+                    'src' => $this->output->image_url('fa-arrow-circle-'.$previcon.'-w', 'format_grid')));
                 $prev .= html_writer::end_tag('div');
                 $next = html_writer::start_tag('div', array('id' => 'gridshadebox_next',
                     'class' => 'gridshadebox_area gridshadebox_next_area '.$areadir,
@@ -390,7 +390,7 @@ class format_grid_renderer extends format_section_renderer_base {
                     'role' => 'link',
                     'aria-label' => get_string('nextsection', 'format_grid')));
                 $next .= html_writer::tag('img', '', array('class' => 'gridshadebox_arrow gridshadebox_next'.$deviceextra,
-                    'src' => $this->output->pix_url('fa-arrow-circle-'.$nexticon.'-w', 'format_grid')));
+                    'src' => $this->output->image_url('fa-arrow-circle-'.$nexticon.'-w', 'format_grid')));
                 $next .= html_writer::end_tag('div');
 
                 if ($rtl) {
@@ -568,7 +568,7 @@ class format_grid_renderer extends format_section_renderer_base {
                             'sesskey' => sesskey(),
                             'course' => $course->id,
                             'showsummary' => 0)), html_writer::empty_tag('img', array(
-                            'src' => $this->output->pix_url('into_grid', 'format_grid'),
+                            'src' => $this->output->image_url('into_grid', 'format_grid'),
                             'alt' => $strhidesummaryalt)) . '&nbsp;' . $strhidesummary, array('title' => $strhidesummaryalt));
             }
         }
@@ -593,7 +593,7 @@ class format_grid_renderer extends format_section_renderer_base {
             if (!file_exists("$CFG->dirroot/course/format/grid/pix/new_activity_".$currentlanguage.".png")) {
                 $currentlanguage = 'en';
             }
-            $urlpicnewactivity = $this->output->pix_url('new_activity_'.$currentlanguage, 'format_grid');
+            $urlpicnewactivity = $this->output->image_url('new_activity_'.$currentlanguage, 'format_grid');
 
             // Get all the section information about which items should be marked with the NEW picture.
             $sectionupdated = $this->new_activity($course);
@@ -812,7 +812,7 @@ class format_grid_renderer extends format_section_renderer_base {
                 'role' => 'img',
                 'aria-label' => $sectionname));
         } else if ($section == 0) {
-            $imgurl = $this->output->pix_url('info', 'format_grid');
+            $imgurl = $this->output->image_url('info', 'format_grid');
             $content = html_writer::empty_tag('img', array(
                 'src' => $imgurl,
                 'alt' => $sectionname,
@@ -858,7 +858,7 @@ class format_grid_renderer extends format_section_renderer_base {
                     'aria-label' => $strdisplaysummaryalt)
                 ),
                 html_writer::empty_tag('img', array(
-                    'src' => $this->output->pix_url('out_of_grid', 'format_grid'),
+                    'src' => $this->output->image_url('out_of_grid', 'format_grid'),
                     'alt' => $strdisplaysummaryalt,
                     'role' => 'img',
                     'aria-label' => $strdisplaysummaryalt)) . '&nbsp;' . $strdisplaysummary,


### PR DESCRIPTION
Fixes deprecation warnings in Moodle 3.3