### PR TITLE
Null sections causes error

### DIFF
--- a/classes/output/courseformat/content/sectionselector.php
+++ b/classes/output/courseformat/content/sectionselector.php
@@ -67,7 +67,7 @@ class sectionselector extends \core_courseformat\output\local\content\sectionsel
         while ($section <= $numsections) {
             if ($section != $data->currentsection) {
                 $thissection = $modinfo->get_section_info($section);
-                if ($format->is_section_visible($thissection)) {
+                if ($thissection !== null && $format->is_section_visible($thissection)) {
                     $url = course_get_url($course, $section, ['navigation' => true]);
                     if ($url) {
                         $sectionmenu[$url->out(false)] = get_section_name($course, $section);


### PR DESCRIPTION
Since moving to the latest version of Grid format for Moodle 4.5 one of our customers has been seeing a issue where there Grid tiles are not accessible and throw the below error, adding a null check fixes this. (Does not happen on all Grid course pages).

Exception - format_grid::is_section_visible(): Argument #1 ($section) must be of type section_info, null given, called in [dirroot]/course/format/grid/classes/output/courseformat/content/sectionselector.php on line 70